### PR TITLE
fix mqtt_client connection parameters

### DIFF
--- a/esp8266_p1meter/esp8266_p1meter.ino
+++ b/esp8266_p1meter/esp8266_p1meter.ino
@@ -81,7 +81,7 @@ bool mqtt_reconnect()
         Serial.printf("MQTT connection attempt %d / %d ...\n", MQTT_RECONNECT_RETRIES, MQTT_MAX_RECONNECT_TRIES);
 
         // * Attempt to connect
-        if (mqtt_client.connect(HOSTNAME, MQTT_USER, MQTT_PASS))
+        if (mqtt_client.connect(MQTT_HOST, MQTT_USER, MQTT_PASS))
         {
             Serial.println(F("MQTT connected!"));
 


### PR DESCRIPTION
Hi - it seems like the mqtt_client.connect is scripted to connect to itself, rather than the MQTT broker. Replaced HOSTNAME with MQTT_HOST (that is coming from settings.h / WifiManager)